### PR TITLE
Add missing call to str.format()

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -115,7 +115,7 @@ def main():
     # check for missing icons
     for app, icon_name in app_icons.items():
         if not icon_name in icons:
-            print("Specified icon '{}' for app '{}' does not exist!")
+            print("Specified icon '{}' for app '{}' does not exist!".format(icon_name, app))
     # build i3-connection
     i3 = i3ipc.Connection()
 


### PR DESCRIPTION
Before:

```console
$ i3-workspace-names-daemon 
Specified icon '{}' for app '{}' does not exist!
```

After:

```console
$ ./i3_workspace_names_daemon.py 
Specified icon 'monitor-heart-rate' for app 'gnome-system-monitor' does not exist!
```

Fixes #2.