### PR TITLE
fixed issue #6 and #8

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -55,19 +55,14 @@ def build_rename(i3, app_icons, delim):
         workdicts = i3.get_workspaces()
         visible =  [workdict['name'] for workdict in workdicts if workdict['visible']]
         visworkspaces = []
-        focus = [workdict['name'] for workdict in workdicts if workdict['focused']]
+        focus = ([workdict['name'] for workdict in workdicts if workdict['focused']] or [None])[0]
         focusname = None
-        if len(focus) > 0:
-            focus = focus[0]
-        else:
-            focus = None
 
         commands = []
         for workspace in workspaces:
             names = [get_icon_or_name(leaf)
                      for leaf in workspace.leaves()]
             names = delim.join(names)
-            newname = ""
             if int(workspace.num) > 0:
                 newname = "{}: {}".format(workspace.num, names)
             else:

--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -38,7 +38,12 @@ def build_rename(i3, app_icons, delim):
         The rename callback.
     """
     def get_icon_or_name(leaf):
-        window_class = leaf.window_class.lower()
+        window_class = ""
+        if leaf.window_class:
+            window_class = leaf.window_class.lower()
+        else:
+            window_class = leaf.name.lower()
+
         if window_class in app_icons and app_icons[window_class] in icons:
             return icons[app_icons[window_class]]
         else:

--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -38,7 +38,6 @@ def build_rename(i3, app_icons, delim):
         The rename callback.
     """
     def get_icon_or_name(leaf):
-        window_class = ""
         if leaf.window_class:
             window_class = leaf.window_class.lower()
         else:


### PR DESCRIPTION
This fixes  #6 by saving the active and focused workspaces prior to renaming them, then re-activates and re-focuses them using the new names assigned to them. Also combines all i3 commands into a single string so that order of activation is preserved, otherwise the wrong workspace may be focused at the end of the rename function. Thanks again for the awesome script @cboddy - it's fantastic for me now that #6 is fixed. I'll be happy to continue assist in maintaining in the future.