### PR TITLE
bugfix: focus loss on multi monitor setup

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -82,8 +82,6 @@ def build_rename(i3, app_icons, delim, length, uniq):
 
             commands.append('rename workspace "{}" to "{}"'.format(workspace.name, newname))
 
-        for workspace in visworkspaces + [focusname]:
-            commands.append('workspace {}'.format(workspace))
 
         # we have to join all the activate workspaces commands into one or the order
         # might get scrambled by multiple i3-msg instances running asyncronously


### PR DESCRIPTION
This change would fix #18 by removing any focus manipulation after renaming workspaces.
Since renaming does not move focus to another window or workspace, I don't see any downsides in doing this.