### PR TITLE
only update changed workspace names

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -80,8 +80,8 @@ def build_rename(i3, app_icons, delim, length, uniq):
             if workspace.name == focus:
                 focusname = newname
 
-            commands.append('rename workspace "{}" to "{}"'.format(workspace.name, newname))
-
+            if workspace.name != newname:
+                commands.append('rename workspace "{}" to "{}"'.format(workspace.name, newname))
 
         # we have to join all the activate workspaces commands into one or the order
         # might get scrambled by multiple i3-msg instances running asyncronously


### PR DESCRIPTION
I had some problems with rhythmbox (music player that displays the song title as window title) stealing my focus on track change. This fixed it and should reduce the amount of commands needing to be sent.

Seems like a simple change to me, but tell me if I didn't take something important into consideration.