### PR TITLE
support chromium web apps

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -40,7 +40,10 @@ def build_rename(i3, app_icons, delim, length, uniq):
     """
     def get_icon_or_name(leaf, length):
         if leaf.window_class:
-            name = leaf.window_class
+            if "chrom" in leaf.window_class.lower():
+                name = leaf.window_instance
+            else:
+                name = leaf.window_class 
         elif leaf.name is not None:
             name = leaf.name
         else:


### PR DESCRIPTION
support `WM_CLASS` of the form `WM_CLASS(STRING) = "<window_instance>", "<window_class>"`
This is useful for web app windows created by e.g. `chromium --app="https://web.whatsapp.com"`, yielding: `WM_CLASS(STRING) = "web.whatsapp.com", "Chromium"`.


Asserting that a window is indeed chromium is tricky since the `WM_CLASS` seems to differ per chromium version and distro; e,g, `Chromium` vs `Google-chrome` vs `Google-chrome-beta` etc. Hence the string comparison with `"chrom"`

Using `window_instace` instead of `window_class` for chromium windows then allows setting the icon on a web-app basis instead of them having the same icon.
