### PR TITLE
Extra match options

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ To match windows with a specific class by their instance instead, specify the cl
 
 This can be useful for browser-based web apps which may all have the same class (for example `google-chrome`) but unique instance values.
 
+### unrecognised windows
+
+If a window is not in the icon config then by default the window title will be displayed instead.
+
+The maximum length of the displayed window title can be set with the command line argument `--max_title_length` or `-l`.
+
+To instead show a specific icon in place of unrecognised windows, specify an icon for window `_no_match` in the icon config.
+
 ### picking icons 
 
 The easiest way to pick an icon is to search for one in the [gallery](https://origin.fontawesome.com/icons?d=gallery). **NB: the "pro" icons are not available in the debian package.**

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ where the key is the name of the i3-window (ie. what is shown in the i3-bar when
 
 Note: the hard-coded list above is used if you don't add this icon-config file.
 
+### matching windows
+
+By default windows are matched by the window class if it is available, otherwise by the window name. If there is no window name available a question mark is shown instead.
+
+To match windows with a specific class by their instance instead, specify the class with the `--instance` or `-i` argument. This can be used multiple times to specify that multiple windows should be matched by their instance.
+
+This can be useful for browser-based web apps which may all have the same class (for example `google-chrome`) but unique instance values.
+
 ### picking icons 
 
 The easiest way to pick an icon is to search for one in the [gallery](https://origin.fontawesome.com/icons?d=gallery). **NB: the "pro" icons are not available in the debian package.**

--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -53,6 +53,8 @@ def build_rename(i3, app_icons, delim, length, uniq, match_instances):
 
         if name in app_icons and app_icons[name] in icons:
             return icons[app_icons[name]]
+        elif "_no_match" in app_icons and app_icons["_no_match"] in icons:
+            return icons[app_icons["_no_match"]]
         else:
             return name[:length]
 


### PR DESCRIPTION
This PR contains 2 commits that I can split out if you want to consider them separately.

1) Windows whose class matches any given by the --instance argument will be matched by instance instead. I've added this for web apps - this is the same approach as PR #23 but will work with different browsers, not just chrome (for example the brave browser).

2) If `_no_match` is defined the in the icon config, use that icon instead of displaying window names for unknown windows.

If you're happy with adding these features, I'm happy to make any changes you'd like to see before merging.