### PR TITLE
Escape any double quotes in workspace names.

### DIFF
--- a/i3_workspace_names_daemon.py
+++ b/i3_workspace_names_daemon.py
@@ -80,7 +80,9 @@ def build_rename(i3, app_icons, delim, length, uniq):
             if workspace.name == focus:
                 focusname = newname
 
-            commands.append('rename workspace "{}" to "{}"'.format(workspace.name, newname))
+            commands.append('rename workspace "{}" to "{}"'.format(
+                # escape any double quotes in old or new name.
+                workspace.name.replace('"','\\"'), newname.replace('"','\\"')))
 
 
         # we have to join all the activate workspaces commands into one or the order


### PR DESCRIPTION
If a workspace name contains quotes (for example, from pango formatting) then
they must be escaped with a backslash when creating the i3 command.